### PR TITLE
Fix login handler; repurpose PlayerLoginEvent -> PlayerJoinEvent

### DIFF
--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -5,8 +5,6 @@ import (
 	"io/fs"
 	"io/ioutil"
 	"os"
-
-	. "github.com/junglemc/JungleTree/pkg/util"
 )
 
 const configFile = "config.toml"

--- a/pkg/event/player.go
+++ b/pkg/event/player.go
@@ -6,20 +6,20 @@ import (
 	"github.com/junglemc/JungleTree/internal/configuration"
 )
 
-type PlayerLoginEvent struct {
+type PlayerJoinEvent struct {
 	Username string
 }
 
-type PlayerLoginListener struct{}
+type PlayerJoinListener struct{}
 
-func (e PlayerLoginEvent) IsAsync() bool {
+func (e PlayerJoinEvent) IsAsync() bool {
 	return true
 }
 
-func (l PlayerLoginListener) OnEvent(event Event) error {
-	e := event.(PlayerLoginEvent)
+func (l PlayerJoinListener) OnEvent(event Event) error {
+	e := event.(PlayerJoinEvent)
 	if configuration.Config().DebugMode {
-		log.Printf("Player connecting: %s\n", e.Username)
+		log.Printf("%s joined the game\n", e.Username)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes the login handler, so that players are able to connect once again. Also, follow the Bukkit event system for easier porting of existing plugins when the time comes - use a JoinEvent here, as it makes more sense.