### PR TITLE
Improved version handling

### DIFF
--- a/cmd/JungleTree.go
+++ b/cmd/JungleTree.go
@@ -10,8 +10,6 @@ import (
 	"github.com/junglemc/JungleTree/pkg/event"
 )
 
-var JungleTreeVersion string
-
 func main() {
 	conf := configuration.Config()
 

--- a/pkg/event/startup.go
+++ b/pkg/event/startup.go
@@ -31,7 +31,7 @@ func (e ServerLoadedEvent) IsAsync() bool {
 
 func (l ServerStartupListener) OnEvent(event Event) error {
 	log.Println(thickLine)
-	log.Println("Starting JungleTree Server v" + pkg.Version)
+	log.Printf("Starting JungleTree Server (Version: %s)\n", pkg.Version)
 	log.Println(thickLine)
 	return nil
 }

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -1,7 +1,8 @@
 package pkg
 
+var Version = ""
+
 const (
 	Brand       = "JungleTree"
-	Version     = "0.0.10"
 	GameVersion = "1.16.5"
 )

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,7 +8,7 @@ build_dir=./dist
 # For cross-compilation
 CGO=0
 
-DEV=true
+: "${DEV:=true}"
 platforms=("linux/amd64" "linux/arm" "linux/arm64" "android/arm64" "darwin/amd64" "darwin/arm64" "windows/amd64")
 
 for platform in "${platforms[@]}"
@@ -20,15 +20,15 @@ do
     if [ $GOOS = "windows" ]; then
         output_name+='.exe'
     fi
-    
+
     if [ "$DEV" = true  ]; then
-        ld='-X github.com/junglemc/JungleTree/pkg.Version='$(git rev-parse HEAD)
+        ld="-X github.com/junglemc/JungleTree/pkg.Version=$(git rev-parse HEAD)"
         tag='-tags dev'
     else
-        ld='-X github.com/junglemc/JungleTree/pkg.Version='${version}
+        ld="-X github.com/junglemc/JungleTree/pkg.Version=v${version}"
         tag=''
     fi
-    
+
     env CGO_ENABLED=$CGO GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "${ld}" $tag -trimpath -o ${build_dir}/${output_name} $package
 
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
Use build tags to load the versioning information, thanks @the-furry-hubofeverything for pointing this out